### PR TITLE
Added missing "/common/pickup/" dependencies

### DIFF
--- a/vehicles/common/pickup/politi/skin.materials.json
+++ b/vehicles/common/pickup/politi/skin.materials.json
@@ -1,0 +1,38 @@
+{
+    "cargobox.skin_van_cargobox.politi_station_box" : {
+        "name" : "cargobox.skin_van_cargobox.politi_station_box",
+        "mapTo" : "cargobox.skin_van_cargobox.politi_station_box",
+        "class" : "Material",
+        "persistentId" : "38c3bd1a-65b9-4d23-86d5-1689115b78e2",
+        "Stages": [
+          {
+            "ambientOcclusionMap": "/vehicles/common/cargobox_ao.data.png",
+            "baseColorMap": "/vehicles/common/cargobox_b.color.png",
+            "metallicMap": "/vehicles/common/cargobox_m.data.png",
+            "metallicFactor": 1,
+            "roughnessFactor": 0.7,
+            "normalMap": "vehicles/common/cargobox_n.dds",
+            "roughnessMap": "/vehicles/common/cargobox_r.data.png",
+            "useAnisotropic": true
+          },
+          {
+            "ambientOcclusionMap": "/vehicles/common/cargobox_ao.data.png",
+            "useAnisotropic": true,
+            "diffuseMapUseUV": 1,
+            "metallicFactor": 0.1,
+            "roughnessMap": "/vehicles/van/politi/skin/rough_cargobox_skin.png",
+            "normalMap": "/vehicles/common/cargobox_n.dds",
+            "opacityMap": "/vehicles/common/cargobox_c.data.png",
+            "baseColorMap": "vehicles/van/politi/skin/cargobox_skin.png"
+          },
+          {},
+          {}
+        ],
+        "activeLayers": 2,
+        "dynamicCubemap": true,
+        "materialTag0": "beamng",
+        "materialTag1": "vehicle",
+        "order_simset": 0,
+        "version": 1.5
+      }
+}


### PR DESCRIPTION
The dependencies for the boxtruck had somehow escaped the zip file when it was created. It was added back correctly. The photoshop files for the skins and other missing files will be merged from a different branch.